### PR TITLE
Changed import of oauth2

### DIFF
--- a/github-notify.go
+++ b/github-notify.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/erwinvaneyk/go-pushbullet"
-	"github.com/golang/oauth2"
+	"golang.org/x/oauth2"
 	"github.com/google/go-github/github"
 	"os"
 	"strconv"


### PR DESCRIPTION
The `github.com/golang/oauth2` confused the Go tool chain:
http://stackoverflow.com/questions/27344013/go-get-error-cant-load-package
